### PR TITLE
Remove from __future__ import annotations

### DIFF
--- a/src/vws_test_fixtures/images.py
+++ b/src/vws_test_fixtures/images.py
@@ -6,8 +6,6 @@ Fixtures for images.
 # https://pytest-cov.readthedocs.io/en/latest/plugins.html
 # for environment variables we have to set to get coverage to work.
 
-from __future__ import annotations
-
 import io
 import secrets
 from pathlib import Path

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -2,12 +2,7 @@
 Test for the new fixtures.
 """
 
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    import io
+import io
 
 
 def test_image_fixtures(


### PR DESCRIPTION
This conflicts with runtime type checking and is not useful