### PR TITLE
Use pytest-beartype-tests plugin

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,21 +2,11 @@
 
 from doctest import ELLIPSIS
 
-import pytest
-from beartype import beartype
 from sybil import Sybil
 from sybil.parsers.rest import (
     DocTestParser,
     PythonCodeBlockParser,
 )
-
-
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Apply the beartype decorator to all collected test functions."""
-    for item in items:
-        if isinstance(item, pytest.Function):
-            item.obj = beartype(obj=item.obj)
-
 
 sybil = Sybil(
     parsers=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ optional-dependencies.dev = [
     "pyrefly==0.61.0",
     "pyright==1.1.408",
     "pyroma==5.0.1",
-    "pytest-beartype-tests==2026.4.19.1",
+    "pytest-beartype-tests",
     "ruff==0.15.11",
     # We add shellcheck-py not only for shell scripts and shell code blocks,
     # but also because having it installed means that ``actionlint-py`` will
@@ -101,6 +101,9 @@ bdist_wheel.universal = true
 #
 # Code to match this is in ``conf.py``.
 version_scheme = "post-release"
+
+[tool.uv]
+sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.24.1",
+    "pytest-beartype-tests==2026.4.19.1",
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://vws-python.github.io/vws-test-fixtures/"
@@ -317,7 +318,6 @@ ignore_path = [
 ignore_names = [
     # pytest configuration
     "pytest_collect_file",
-    "pytest_collection_modifyitems",
     "pytest_plugins",
     # pytest fixtures - we name fixtures like this for this purpose
     "fixture_*",
@@ -354,3 +354,6 @@ exclude = [ ".venv" ]
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
+
+[dependency-groups]
+dev = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ optional-dependencies.dev = [
     "pyrefly==0.61.0",
     "pyright==1.1.408",
     "pyroma==5.0.1",
+    "pytest-beartype-tests==2026.4.19.1",
     "ruff==0.15.11",
     # We add shellcheck-py not only for shell scripts and shell code blocks,
     # but also because having it installed means that ``actionlint-py`` will
@@ -72,12 +73,14 @@ optional-dependencies.dev = [
     "vulture==2.16",
     "yamlfix==1.19.1",
     "zizmor==1.24.1",
-    "pytest-beartype-tests==2026.4.19.1",
 ]
 optional-dependencies.release = [ "check-wheel-contents==0.6.3" ]
 urls.Documentation = "https://vws-python.github.io/vws-test-fixtures/"
 urls.Source = "https://github.com/VWS-Python/vws-test-fixtures"
 entry-points.pytest11.vws_test_fixtures = "vws_test_fixtures.plugin"
+
+[dependency-groups]
+dev = []
 
 [tool.setuptools]
 zip-safe = false
@@ -354,6 +357,3 @@ exclude = [ ".venv" ]
 [tool.yamlfix]
 section_whitelines = 1
 whitelines = 1
-
-[dependency-groups]
-dev = []


### PR DESCRIPTION
This PR adds the [`pytest-beartype-tests`](https://github.com/adamtheturtle/pytest-beartype-tests) dev dependency and removes redundant `pytest_collection_modifyitems` / `@beartype` wiring from conftest where it duplicated the plugin.

The plugin registers via `pytest11` and applies `@beartype` to collected test functions, matching the previous local hook behavior (see the [upstream README](https://github.com/adamtheturtle/pytest-beartype-tests)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only changes test-time type-checking/wrapping behavior and dev tooling, with no production code impact; main risk is subtle differences in how the external plugin applies `beartype` to collected tests.
> 
> **Overview**
> Switches from a custom `pytest_collection_modifyitems` hook in `conftest.py` to the external `pytest-beartype-tests` plugin to apply `@beartype` to collected test functions.
> 
> Updates `pyproject.toml` to add `pytest-beartype-tests` to dev dependencies, pins its source via `uv`, adds an empty `[dependency-groups]` `dev` group, and removes the now-unused vulture ignore for `pytest_collection_modifyitems`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f57a223e7ce8bfdd12b703e0d770570dcf67238. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->