### PR TITLE
Pin pytest-beartype-tests to 2026.4.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ optional-dependencies.dev = [
     "pyrefly==0.61.0",
     "pyright==1.1.408",
     "pyroma==5.0.1",
-    "pytest-beartype-tests",
+    "pytest-beartype-tests==2026.4.20",
     "ruff==0.15.11",
     # We add shellcheck-py not only for shell scripts and shell code blocks,
     # but also because having it installed means that ``actionlint-py`` will
@@ -103,7 +103,6 @@ bdist_wheel.universal = true
 version_scheme = "post-release"
 
 [tool.uv]
-sources.pytest-beartype-tests = { git = "https://github.com/adamtheturtle/pytest-beartype-tests.git", rev = "bc81d99" }
 
 [tool.ruff]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,8 +102,6 @@ bdist_wheel.universal = true
 # Code to match this is in ``conf.py``.
 version_scheme = "post-release"
 
-[tool.uv]
-
 [tool.ruff]
 line-length = 79
 lint.select = [


### PR DESCRIPTION
Pin `pytest-beartype-tests` to PyPI [`2026.4.20`](https://pypi.org/project/pytest-beartype-tests/2026.4.20/), which includes the Sybil-safe plugin change, and drop the temporary `[tool.uv.sources]` git override.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pinning/config-only change in `pyproject.toml`, with no runtime code changes; main risk is CI/test behavior differences from the new plugin version.
> 
> **Overview**
> Pins the dev dependency `pytest-beartype-tests` to the PyPI release `2026.4.20` instead of an unpinned requirement.
> 
> Removes the temporary `uv` git source override (`[tool.uv].sources.pytest-beartype-tests`) now that the needed changes are available via PyPI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b470feaeb354c95618372ec1d6f948af6c4f5e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->