### PR TITLE
Use importlib.resources to load bundled image data

### DIFF
--- a/src/vws_test_fixtures/images.py
+++ b/src/vws_test_fixtures/images.py
@@ -2,7 +2,7 @@
 
 import io
 import secrets
-from pathlib import Path
+from importlib.resources import files
 from typing import Literal
 
 import pytest
@@ -58,8 +58,8 @@ def high_quality_image() -> io.BytesIO:
 
     At the time of writing, this image gains a tracking rating of 5.
     """
-    path = Path(__file__).parent / "high_quality_image.jpg"
-    return io.BytesIO(initial_bytes=path.read_bytes())
+    resource = files(anchor=__package__) / "high_quality_image.jpg"
+    return io.BytesIO(initial_bytes=resource.read_bytes())
 
 
 @pytest.fixture
@@ -167,5 +167,5 @@ def different_high_quality_image() -> io.BytesIO:
 
     This is necessarily different to ``high_quality_image``.
     """
-    path = Path(__file__).parent / "different_high_quality_image.jpg"
-    return io.BytesIO(initial_bytes=path.read_bytes())
+    resource = files(anchor=__package__) / "different_high_quality_image.jpg"
+    return io.BytesIO(initial_bytes=resource.read_bytes())


### PR DESCRIPTION
## Summary
- Replace `Path(__file__).parent` with `importlib.resources.files(anchor=__package__)` in `high_quality_image` and `different_high_quality_image` fixtures so package data is loaded via the resources API rather than filesystem assumptions about `__file__`.

## Test plan
- [x] `uv run pytest tests/test_fixtures.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test fixture change only, switching image loading to the standard resources API to avoid relying on filesystem paths.
> 
> **Overview**
> Updates the `high_quality_image` and `different_high_quality_image` pytest fixtures to load bundled JPGs via `importlib.resources.files(anchor=__package__)` instead of `Path(__file__).parent`.
> 
> This makes fixture image loading work consistently when the package is installed or packaged without direct filesystem access to `__file__`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4605340b78e5562a642f9fcd60035206130d24cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->