### PR TITLE
Bump mypy to 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ optional-dependencies.dev = [
     "doccmd==2026.3.26.2",
     "furo==2025.12.19",
     "interrogate==1.7.0",
-    "mypy[faster-cache]==1.20.2",
+    "mypy[faster-cache]==2.0.0",
     "mypy-strict-kwargs==2026.1.12",
     "prek==0.3.13",
     "pydocstringformatter==0.7.5",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only updates a dev-only type-checking dependency, with no runtime or production code changes. Possible CI/type-check differences if `mypy` 2.0.0 introduces stricter checks or new errors.
> 
> **Overview**
> Updates the dev dependency pin for `mypy[faster-cache]` in `pyproject.toml` from `1.20.2` to `2.0.0`, so local/CI type-checking runs use MyPy 2.x.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a38c80cfb15c958d7921a4e67046c35933387288. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->