### PR TITLE
Enable mypy parallel workers in pre-commit.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,7 +156,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev -m mypy
+        entry: uv run --extra=dev --with ast-serialize -m mypy --num-workers 4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -167,9 +167,12 @@ repos:
       - id: mypy-docs
         name: mypy-docs
         stages: [pre-push]
-        entry: uv run --extra=dev doccmd --no-write-to-file --language=python --command="mypy"
+        entry: uv run --extra=dev --with ast-serialize doccmd --no-write-to-file --example-workers
+          1 --language=python --command="mypy --num-workers 4"
         language: python
         types_or: [markdown, rst]
+        additional_dependencies:
+          - *uv_version
 
       - id: check-manifest
         name: check-manifest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,7 +156,7 @@ repos:
       - id: mypy
         name: mypy
         stages: [pre-push]
-        entry: uv run --extra=dev --with ast-serialize -m mypy --num-workers 4
+        entry: uv run --extra=dev --with ast-serialize -m mypy --num-workers=4
         language: python
         types_or: [python, toml]
         pass_filenames: false
@@ -168,7 +168,7 @@ repos:
         name: mypy-docs
         stages: [pre-push]
         entry: uv run --extra=dev --with ast-serialize doccmd --no-write-to-file --example-workers
-          1 --language=python --command="mypy --num-workers 4"
+          1 --language=python --command="mypy --num-workers=4"
         language: python
         types_or: [markdown, rst]
         additional_dependencies:


### PR DESCRIPTION
## Summary
- configure the `mypy` pre-push hook to use 4 workers
- update `mypy-docs` to run examples safely with one doccmd worker while invoking mypy with 4 workers
- include `ast-serialize` in hook execution so parallel mypy runs do not fail with `ModuleNotFoundError`

## Test plan
- [x] `pre-commit run mypy --all-files --hook-stage pre-push`
- [x] `pre-commit run mypy-docs --all-files --hook-stage pre-push`

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts local pre-push pre-commit hook commands, affecting developer CI ergonomics rather than runtime behavior.
> 
> **Overview**
> Updates the `mypy` and `mypy-docs` pre-push hooks to run mypy with **4 parallel workers** (`--num-workers=4`) to speed up type checking.
> 
> To keep parallel runs stable, both hooks now execute via `uv` with `--with ast-serialize`, and `mypy-docs` is adjusted to use `doccmd` with **one example worker** while invoking mypy in parallel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5898036fc33a7e6cfd6e64fc03599b27fdefd7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->