### PR TITLE
[codex] Make useless Pylint suppressions fail lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,6 +181,10 @@ MASTER.load-plugins = [
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 MASTER.unsafe-load-any-extension = false
+# Return non-zero exit code if useless-suppression is emitted.
+MAIN.fail-on = [
+    "useless-suppression",
+]
 DEPRECATED_BUILTINS.bad-functions = [
     # Use Pylint until Ruff can ban bare builtin calls, or until custom rules
     # make this removable:


### PR DESCRIPTION
## Summary

- Configure Pylint to fail when `useless-suppression` is emitted.
- Keep existing useless-suppression enablement and project-specific Pylint settings intact.

## Validation

- Parsed `pyproject.toml` with `tomllib`.
- Ran `pylint --rcfile pyproject.toml --list-msgs-enabled`.
- Ran repository commit hooks for the changed file.