### PR TITLE
Bump beartype to 0.23.0rc0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 ]
 optional-dependencies.dev = [
     "actionlint-py==1.7.12.24",
-    "beartype==0.22.9",
+    "beartype==0.23.0rc0",
     "check-manifest==0.51",
     "coverage==7.15.3",
     "deptry==0.25.1",


### PR DESCRIPTION
Tests the [beartype 0.23.0rc0](https://pypi.org/project/beartype/0.23.0rc0/) release candidate against this repository's test suite.

Pins `beartype` to the release candidate in `pyproject.toml` and updates `uv.lock` to match.

Not intended to merge as-is — the pin should be relaxed once the release candidate has been evaluated.