### PR TITLE
Configure mypy to respect gitignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -339,6 +339,7 @@ max_supported_python = "3.14"
 [tool.mypy]
 files = [ "." ]
 exclude = [ "build" ]
+exclude_gitignore = true
 follow_untyped_imports = true
 strict = true
 plugins = [


### PR DESCRIPTION
## Summary

- configure mypy with `exclude_gitignore = true`
- prevent files ignored by Git from being included in mypy discovery

## Impact

Mypy will respect the project's `.gitignore` rules when discovering files. This avoids type-checking generated, local, or otherwise ignored files.

## Validation

- formatted and parsed `pyproject.toml` with `pyproject-fmt`
- verified the branch diff is exactly one added line in `pyproject.toml`
- ran Git whitespace validation
